### PR TITLE
Add support for literals as function arguments

### DIFF
--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -76,7 +76,12 @@ defmodule Sanskrit.Parser do
           char("("),
           many(
             choice([
-              variable(),
+              choice([
+                variable(),
+                float(),
+                integer(),
+                literal_string()
+              ]),
               ignore(spaces()),
               ignore(char(","))
             ])

--- a/test/sanskrit_test.exs
+++ b/test/sanskrit_test.exs
@@ -85,11 +85,41 @@ defmodule SanskritTest do
     assert {:ok, []} = Sanskrit.parse("\n")
   end
 
-  test "can parse functions" do
-    assert {:ok, [{:fun, "$name", "surname_of", ["$sinisi"]}]} =
-             parse("""
-             let $name = surname_of($sinisi)
-             """)
+  describe "parse functions" do
+    test "variable args" do
+      assert {:ok, [{:fun, "$name", "surname_of", ["$sinisi"]}]} =
+               parse("""
+               let $name = surname_of($sinisi)
+               """)
+    end
+
+    test "integer literal args" do
+      assert {:ok, [{:fun, "$result", "div", [10, 5]}]} =
+               parse("""
+               let $result = div(10, 5)
+               """)
+    end
+
+    test "float literal args" do
+      assert {:ok, [{:fun, "$result", "div", [10.1, 5.3]}]} =
+               parse("""
+               let $result = div(10.1, 5.3)
+               """)
+    end
+
+    test "string literal args" do
+      assert {:ok, [{:fun, "$result", "myfunc", ["yo", "dude"]}]} =
+               parse("""
+               let $result = myfunc("yo", "dude")
+               """)
+    end
+
+    test "mixed literal args" do
+      assert {:ok, [{:fun, "$result", "myfunc", ["yo", 12, 42.66, "$var"]}]} =
+               parse("""
+               let $result = myfunc("yo", 12, 42.66, $var)
+               """)
+    end
   end
 
   test "can parse Wme" do


### PR DESCRIPTION
So we can parse for example `div($mything, 12)`